### PR TITLE
[FEAT] 회원가입 화면 구현 (상세내용참고)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bootstrap": "^5.3.5",
     "bootstrap-vue-3": "^0.3.12",
     "vue": "^3.5.13",
+    "vue-datepicker-next": "^1.0.3",
     "vue-router": "^4.0.13"
   },
   "devDependencies": {

--- a/src/components/BaseModal.vue
+++ b/src/components/BaseModal.vue
@@ -1,0 +1,91 @@
+<template>
+    <div class="modal-overlay" @click.self="$emit('close')">
+      <div class="dark-modal">
+        <h2 class="modal-title" v-if="title">{{ title }}</h2>
+  
+        <div class="modal-content-scroll">
+          <slot />
+        </div>
+  
+        <div class="modal-buttons">
+          <slot name="action-buttons" />
+        </div>
+      </div>
+    </div>
+  </template>
+  
+  <script setup>
+  defineProps({
+    title: {
+      type: String,
+      default: '',
+    },
+  })
+  </script>
+  
+  <!-- ❗ scoped 제거됨 -->
+  <style>
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: rgba(0, 0, 0, 0.6);
+  
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  
+  .dark-modal {
+    background: #222;
+    color: #fff;
+    font-family: 'Noto Sans KR', sans-serif;
+  
+    width: 430px;
+    height: 70vh;
+    max-height: 70vh;
+    padding: 24px;
+    border-radius: 12px;
+  
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .modal-title {
+    font-size: 20px;
+    font-weight: bold;
+    margin-bottom: 16px;
+    text-align: center;
+  }
+  
+  .modal-content-scroll {
+    flex: 1;
+    overflow-y: auto;
+    padding-right: 10px;
+    font-size: 13px;
+    line-height: 1.8;
+  }
+  
+  .modal-content-scroll h3 {
+    font-size: 15px;
+    margin-top: 24px;
+    font-weight: bold;
+  }
+  
+  .modal-content-scroll ul {
+    padding-left: 20px;
+    margin: 12px 0;
+  }
+  
+  .modal-content-scroll li {
+    margin-bottom: 10px;
+  }
+  
+  .modal-buttons {
+    display: flex;
+    justify-content: space-evenly;
+    margin-top: 24px;
+    width: 100%;
+  }
+  </style>
+  

--- a/src/components/login/BirthDateField.vue
+++ b/src/components/login/BirthDateField.vue
@@ -1,0 +1,100 @@
+<!-- components/BirthDateField.vue -->
+<template>
+    <div class="input-wrapper" :class="{ focused: isFocused }">
+      <DatePicker
+        v-model:value="modelValueProxy"
+        type="date"
+        format="YYYY-MM-DD"
+        :input-attr="{
+          readonly: true,
+          placeholder: '생년월일 선택',
+          class: 'datepicker-input'
+        }"
+        @focus="isFocused = true"
+        @close="isFocused = false"
+        />
+    </div>
+</template>
+  
+<script setup>
+  import { ref, computed } from 'vue'
+  import DatePicker from 'vue-datepicker-next'
+  import 'vue-datepicker-next/index.css'
+  
+  const props = defineProps({
+    modelValue: String,
+    placeholder: String,
+  })
+  const emit = defineEmits(['update:modelValue'])
+  
+  const isFocused = ref(false)
+  
+  const modelValueProxy = computed({
+    get: () => props.modelValue,
+    set: val => emit('update:modelValue', val),
+  })
+ </script>
+  
+<style scoped>
+  .input-wrapper {
+    position: relative;
+    width: 500px;
+    height: 80px;
+    border: 2px solid #ffffff;
+    padding: 0 20px;
+    display: flex;
+    align-items: center;
+    transition: border-color 0.2s ease;
+    background: transparent;
+    box-sizing: border-box;
+  }
+  
+  .input-wrapper.focused {
+    border-color: #fd6f22;
+  }
+  
+  .datepicker-input {
+    flex: 1;
+    height: 100%;
+    border: none;
+    outline: none;
+    font-size: 24px;
+    font-family: "Noto Sans KR", sans-serif;
+    background: transparent;
+    color: #ffffff;
+    caret-color: #ffffff;
+  }
+  
+  .datepicker-input::placeholder {
+    color: #808080;
+  }
+
+</style>
+  
+
+<!-- BirthDateField.vue -->
+<style>
+/* App.vue or BirthDateField.vue의 전역 style 블록에 */
+    .mx-datepicker-main {
+    background-color: #1a1a1a !important;
+    color: white !important;
+    border: 1px solid #fd6f22 !important;
+    border-radius: 8px !important;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    }
+
+    .cell.active {
+    background-color: #fd6f22 !important;
+    color: white !important;
+    }
+
+    .mx-btn {
+    background: none !important;
+    color: white !important;
+    }
+
+    .mx-calendar-header-label button {
+    color: white !important;
+    }
+
+</style>

--- a/src/components/login/InputField.vue
+++ b/src/components/login/InputField.vue
@@ -6,6 +6,7 @@
       v-model="modelValueProxy"
       @focus="isFocused = true"
       @blur="handleBlur"
+      :readonly="readonly"
       :autocomplete="type === 'password' ? 'current-password' : 'on'"
     />
     <img
@@ -30,6 +31,7 @@ const props = defineProps({
     type: String,
     default: 'text',
   },
+  readonly: Boolean,
 })
 
 const emit = defineEmits(['update:modelValue'])
@@ -68,7 +70,6 @@ const togglePasswordVisible = () => {
   padding: 0 20px;
   display: flex;
   align-items: center;
-  background-color: #1e1e1e;
   transition: border-color 0.2s ease;
 }
 

--- a/src/pages/PreSignupPage.vue
+++ b/src/pages/PreSignupPage.vue
@@ -1,0 +1,146 @@
+<template>
+    <header> 
+    <Header /> 
+  </header>
+
+  <div class="wrapper">
+    <div class="scaler" :style="scaleStyle">
+      <div class="login-container">
+        <!-- 왼쪽 -->
+        <div class="welcome-section">
+          <h1 class="welcome-title">환영해요!</h1>
+          <img src="../assets/icons/marktory-cat.svg" alt="고양이" class="cat-image" />
+          <p class="welcome-text">Marktory는 모든 사람의<br />이야기를 기다립니다.</p>
+        </div>
+
+        <!-- 오른쪽 -->
+        <div class="login-section">
+          <img src="../assets/icons/marktory-logo.svg" alt="로고" class="logo" />
+          <InputField v-model="email" placeholder="이메일을 입력하세요" type="email" />
+          <LoginButton @click="sendEmail" text="이메일 전송" />
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <Footer>
+    <Footer/>
+  </Footer>   
+</template>
+
+<script setup>
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+import InputField from '../components/login/InputField.vue'
+import LoginButton from '../components/login/LoginButton.vue'
+import Header from '../components/AppHeader.vue'
+import Footer from '../components/footer/AppFooter.vue'
+
+const email = ref('')
+const scaleStyle = ref({})
+
+const baseWidth = 1920
+const baseHeight = 1080
+
+const updateScale = () => {
+  const scaleX = window.innerWidth / baseWidth
+  const scaleY = window.innerHeight / baseHeight
+  const scale = Math.min(scaleX, scaleY)
+  const offsetX = (window.innerWidth - baseWidth * scale) / 2
+  const offsetY = (window.innerHeight - baseHeight * scale) / 2 - 60
+
+  scaleStyle.value = {
+    transform: `translate(${offsetX}px, ${offsetY}px) scale(${scale})`,
+    transformOrigin: 'top left',
+    position: 'absolute',
+    width: `${baseWidth}px`,
+    height: `${baseHeight}px`,
+    top: 0,
+    left: 0,
+  }
+}
+
+onMounted(() => {
+  updateScale()
+  window.addEventListener('resize', updateScale)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateScale)
+})
+
+const sendEmail = () => {
+  if (!email.value) {
+    alert('이메일을 입력해주세요.')
+    return
+  }
+
+  alert(`이메일이 전송되었습니다. ${email.value}`)
+}
+</script>
+
+<style scoped>
+.wrapper {
+  width: 100vw;
+  height: 90vh;
+  background-color: #000;
+  overflow: hidden;
+  position: relative;
+}
+
+.scaler {
+  will-change: transform;
+}
+
+.login-container {
+  display: flex;
+  width: 1920px;
+  height: 1080px;
+  font-family: "Noto Sans KR", sans-serif;
+  color: white;
+}
+
+/* 왼쪽 */
+.welcome-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 40px;
+  box-sizing: border-box;
+}
+
+.welcome-title {
+  font-size: 40px;
+  font-weight: bold;
+}
+
+.cat-image {
+  width: 260px;
+  height: auto;
+}
+
+.welcome-text {
+  font-size: 32px;
+  text-align: center;
+  font-weight: bold;
+  line-height: 1.4;
+}
+
+/* 오른쪽 */
+.login-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 40px;
+}
+
+.logo {
+  width: 500px;
+  margin-bottom: 16px;
+}
+</style>

--- a/src/pages/SignupPage.vue
+++ b/src/pages/SignupPage.vue
@@ -1,0 +1,286 @@
+<template>
+  <header>
+    <Header />
+  </header>
+
+  <div class="wrapper">
+    <div class="scaler" :style="scaleStyle">
+      <div class="signup-container">
+        <!-- 왼쪽 인사말 영역 -->
+        <div class="welcome-section">
+          <h1 class="welcome-title">환영해요!</h1>
+          <img src="../assets/icons/marktory-cat.svg" alt="고양이" class="cat-image" />
+          <p class="welcome-text">
+            Marktory는 모든 사람의<br />이야기를 기다립니다.
+          </p>
+        </div>
+
+        <!-- 오른쪽 입력 영역 -->
+        <div class="form-section">
+          <img src="../assets/icons/marktory-logo.svg" alt="로고" class="logo" />
+
+          <InputField v-model="name" placeholder="이름" />
+          <p v-if="!name && triedSubmit" class="error">필수 항목입니다.</p>
+
+          <InputField v-model="nickname" placeholder="닉네임" />
+          <p v-if="!nickname && triedSubmit" class="error">필수 항목입니다.</p>
+
+          <InputField v-model="password" placeholder="비밀번호" type="password" />
+          <p v-if="password && !validPassword" class="error">
+            8~16자 영문 대소문자, 숫자, 특수문자를 사용하세요.
+          </p>
+
+          <InputField v-model="confirmPassword" placeholder="비밀번호 확인" type="password" />
+          <p v-if="confirmPassword && !passwordsMatch" class="error">비밀번호가 일치하지 않습니다.</p>
+
+          <!-- 생년월일 입력 -->
+          <BirthDateField v-model="birth" />
+
+          <div class="checkbox" :class="{ agreed: agree }" @click="showModal = true">
+            <div class="checkbox-custom" :class="{ checked: agree }"></div>
+            <span class="agree-text">개인정보 이용약관 동의</span>
+          </div>
+
+          <LoginButton text="회원가입" @click="handleSignup" />
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <Footer><Footer /></Footer>
+
+	<BaseModal v-if="showModal" title="운영정책" @close="showModal = false">
+		<!-- 약관 내용 -->
+      <h3>1. 마크토리 서비스</h3>
+      <ul>
+        <li>마크토리는 나와 내 콘텐츠를 표현하는 공간입니다.</li>
+				<li>마크토리는 자신의 게시글과 마크다운 문법을 이용한 템플릿을 통해 자신에 대한 소개와 자신의 콘텐츠를 자유자재로 선보일 수 있습니다. </li>
+        <li>마크토리는 커뮤니티에서의 에티켓을 준수합니다.</li>
+        <li>이용자의 기본 권리를 우선시합니다.</li>
+      </ul>
+
+      <h3>2. 이용 제한 사유에 금지되는 해당 활동</h3>
+      <ul>
+        <li>다른 이용자에게 욕설, 비하, 혐오 발언, 협박 등 불쾌감을 주는 메시지를 전송하는 행위</li>
+        <li>반복적이거나 무분별한 메시지 발송(스팸)으로 타인의 서비스 이용을 방해하는 행위</li>
+        <li>타인의 개인정보(이름, 연락처, 주소 등)를 동의 없이 유포하거나 요청하는 행위</li>
+      </ul>
+
+      <h3>3. 이용 제한 조치</h3>
+      <ul>
+        <li>조치할 수 있고 회원의 서비스 이용을 일시적 또는 영구적으로 제한하거나 일방적으로 본 계약을 해지할 수 있습니다.</li>
+        <li> 본 운영정책 2.에서 열거한 행위에 구체적으로 해당하지 않는 사항이라하더라도 건전한 서비스 환경 제공에 악영향을 끼치는 경우는 이용이 제한될 수 있으며, 위반되는 활동이 반복되는 경우 가중 처리될 수 있습니다.</li>
+      </ul>
+      <!-- 커스텀 액션 버튼 슬롯 -->
+			<template #action-buttons>
+				<button @click="showModal = false" class="cancel-btn">취소</button>
+				<button @click="agree = true; showModal = false" class="agree-btn">확인</button>
+			</template>
+	</BaseModal>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import InputField from '../components/login/InputField.vue'
+import LoginButton from '../components/login/LoginButton.vue'
+import Header from '../components/AppHeader.vue'
+import Footer from '../components/footer/AppFooter.vue'
+import BirthDateField from '../components/login/BirthDateField.vue'
+import BaseModal from '../components/BaseModal.vue'
+
+const name = ref('')
+const nickname = ref('')
+const password = ref('')
+const confirmPassword = ref('')
+const birth = ref('')
+const agree = ref(false)
+const showModal = ref(false)
+const triedSubmit = ref(false)
+
+const validPassword = computed(() =>
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{8,16}$/.test(password.value)
+)
+const passwordsMatch = computed(() => password.value === confirmPassword.value)
+
+const handleSignup = () => {
+  triedSubmit.value = true
+
+  const validations = [
+    { condition: !name.value, message: '이름을 입력해주세요.' },
+    { condition: !nickname.value, message: '닉네임을 입력해주세요.' },
+    { condition: !password.value, message: '비밀번호를 입력해주세요.' },
+    { condition: !confirmPassword.value, message: '비밀번호를 확인해주세요.' },
+    { condition: !agree.value, message: '개인정보 이용약관에 동의해주세요.' },
+    { condition: !birth.value, message: '생년월일을 입력해주세요.' },
+    { condition: !validPassword.value || !passwordsMatch.value, message: '비밀번호 조건을 확인해주세요.' },
+  ]
+
+  for (const { condition, message } of validations) {
+    if (condition) {
+      alert(message)
+      return
+    }
+  }
+
+  alert('🎉 회원가입 성공! (실제 API 연결은 아직)')
+}
+
+const scaleStyle = ref({})
+const baseWidth = 1920
+const baseHeight = 1080
+
+const updateScale = () => {
+  const scaleX = window.innerWidth / baseWidth
+  const scaleY = window.innerHeight / baseHeight
+  const scale = Math.min(scaleX, scaleY)
+  const offsetX = (window.innerWidth - baseWidth * scale) / 2
+  const offsetY = (window.innerHeight - baseHeight * scale) / 2 - 60
+
+  scaleStyle.value = {
+    transform: `translate(${offsetX}px, ${offsetY}px) scale(${scale})`,
+    transformOrigin: 'top left',
+    width: `${baseWidth}px`,
+    height: `${baseHeight}px`,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+		zIndex: 10,
+  }
+}
+
+onMounted(() => {
+  updateScale()
+  window.addEventListener('resize', updateScale)
+})
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateScale)
+})
+</script>
+
+<style scoped>
+.wrapper {
+  width: 100vw;
+  height: 90vh;
+  position: relative;
+}
+.signup-container {
+  display: flex;
+  width: 1920px;
+  height: 1080px;
+  font-family: 'Noto Sans KR', sans-serif;
+  color: white;
+}
+.welcome-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 24px;
+  padding: 40px;
+}
+.cat-image {
+  width: 260px;
+}
+.welcome-title {
+  font-size: 40px;
+  font-weight: bold;
+}
+.welcome-text {
+  font-size: 32px;
+  text-align: center;
+  font-weight: bold;
+  line-height: 1.4;
+}
+.form-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  padding: 40px;
+}
+.logo {
+  width: 500px;
+  margin-bottom: 16px;
+}
+.error {
+  color: #ff5050;
+  font-size: 14px;
+  margin-top: -12px;
+  margin-bottom: 4px;
+  width: 500px;
+}
+.checkbox {
+  width: 500px;
+  display: flex;
+  align-items: center;
+  font-size: 20px;
+  gap: 12px;
+  margin: 8px 0;
+  color: white;
+  cursor: pointer;
+}
+.checkbox.agreed {
+  color: #fd6f22;
+}
+.checkbox-custom {
+  width: 24px;
+  height: 24px;
+  border: 2px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.checkbox-custom.checked {
+  background-color: #fd6f22;
+  border-color: #fd6f22;
+}
+.agree-text {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.cancel-btn {
+  padding: 10px 24px;
+  background: #444;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-weight: bold;
+  cursor: pointer;
+	width: 83px;
+	height: 33px;
+
+	display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.agree-btn {
+  padding: 10px 24px;
+  background: #fd6f22;
+  border: none;
+  border-radius: 8px;
+  color: white;
+  font-weight: bold;
+  cursor: pointer;
+	width: 83px;
+	height: 33px;
+
+	display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.agree-btn:hover {
+  background-color: white;
+  color: #fd6f22;
+  /* border: 1px solid #fd6f22; */
+}
+.cancel-btn:hover {
+  background-color: #BDBDBD;
+
+  /* border: 1px solid #fd6f22; */
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,6 +20,14 @@ const router = createRouter({
             component: () => import('../pages/FindIdPage.vue')
         },
         {
+            path: '/signup',
+            component: () => import('../pages/SignupPage.vue')
+        },
+        {
+            path: '/presignup',
+            component: () => import('../pages/PreSignupPage.vue')
+        },
+        {
             path: '/mypage',
             component: () => import('../pages/MyPage.vue'),
             children: [


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
- 생년월일 달력 활용 "vue-datepicker-next" 추가
- 달력 활용한 입력 컴포넌트 구현: src/components/login/BirthDateField.vue
- 모달 공통 검포넌트 구현: src/components/BaseModal.vue
- 회원가입 전 이메일 인증 화면 구현: src/pages/PreSignupPage.vue
- 이메일 인증 후 회원 정보 입력 화면 구현: src/pages/SignupPage.vue
- > 예외처리 한다고 했는데, 원하는 대로 수정해도 됨

## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)

## ✅ 체크리스트 (Checklist)
- [ ] 코드에 오류가 없는지 확인하셨나요?
- [ ] 주요 변경 사항을 문서화하셨나요?
- [ ] 단위 테스트 또는 통합 테스트를 추가했나요? (해당하는 경우)
- [ ] 리뷰어가 확인해야 할 포인트가 있다면 적어주세요.

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

---
