### PR TITLE
[REFACTOR] sidefooter 축소 시 화면 표시, footer 수정

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,12 +10,14 @@
   
   <main id="app" class="theme-dark">
     <RouterView />
+    <SideFooter/>
   </main>
 
 </template>
 
 <script setup>
 import { RouterView } from 'vue-router';
+import SideFooter from "@/components/footer/SideFooter.vue";
 </script>
 
 <style>

--- a/src/components/footer/AppFooter.vue
+++ b/src/components/footer/AppFooter.vue
@@ -21,7 +21,8 @@
     bottom: 10px;
     left: 50%;
     transform: translateX(-50%);
-    width: 400px;
+    width: 90%;              /* ✅ 400px → 퍼센트로 유연하게 */
+    max-width: 400px;        /* ✅ 최대폭은 유지 */
     height: 62px;
     display: flex;
     flex-direction: column;
@@ -32,18 +33,21 @@
     font-size: 20px;
     color: #808080;
     z-index: 100;
+    padding-top: 10px;
 }
 
 .footer-links {
 width: 400px;
 height: 22px;
+flex-direction: row;
+
 display: flex;
-justify-content: space-between;
+justify-content: space-evenly;
 align-items: center;
 }
 
 .footer-link {
-font-size: 22px;
+font-size: 18px;
 font-weight: 500;
 color: #888888;
 text-decoration: none;

--- a/src/components/footer/SideFooter.vue
+++ b/src/components/footer/SideFooter.vue
@@ -2,7 +2,7 @@
     사이드에 있는 Footer
 -->
 <template>
-    <footer class="footer">
+    <footer v-if="isNarrow" class="footer">
         <div class="footer-info">
             <p>마크토리</p>
             <p>사업자등록번호 : 123-45-67899</p>
@@ -18,17 +18,36 @@
 </template>
 
 <script setup>
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+
+const isNarrow = ref(false)
+
+const checkWidth = () => {
+  isNarrow.value = window.innerWidth >= 2000
+}
+
+onMounted(() => {
+  checkWidth()
+  window.addEventListener('resize', checkWidth)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', checkWidth)
+})
 </script>
 
-<style scoped>
+<style>
 .footer {
+    display: none;
+
     position: fixed;
     bottom: 0;
     left: 0;
-    width: 172px;
-    height: 125px;
+		width: 20%; /* ✅ px 대신 % */
+		min-width: 100px; /* 너무 작아지는 것 방지 */
+    height: 150px;
     font-family: 'Noto Sans KR', sans-serif;
-    font-size: 10px;
+    font-size: 15px;
     font-weight: bold;
     color: #D4D4D4;
     padding: 6px 8px;              /* ✅ 줄임 */
@@ -38,7 +57,10 @@
     box-sizing: border-box;
     overflow: hidden;              /* ✅ 안전 */
     z-index: 100;
+		margin-bottom: 25px;
+		padding-bottom: 10px;
 }
+
 
 .footer-info p {
     margin: 0 0 2px 0;


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
- sidefooter 전역 적용
- sidefooter 화면 축소 시 화면 표시
- sidefooter 수정 후 footer 정렬 재배치

## 📌 변경 사항 (Changes)
- [x] 주요 기능 추가 / 변경
- [x] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)


## 📂 관련 이슈 (Issue)
- #40 

## ✅ 체크리스트 (Checklist)
- [ ] 코드에 오류가 없는지 확인하셨나요?
- [ ] 주요 변경 사항을 문서화하셨나요?
- [ ] 단위 테스트 또는 통합 테스트를 추가했나요? (해당하는 경우)
- [ ] 리뷰어가 확인해야 할 포인트가 있다면 적어주세요.

## 💡 추가 설명 (Additional Info)
- ❗이미 적용시킨 sidefooter는 제거해주시면 됩니다.
- 만약 화면 축소 시 가운데 중심으로 축소가 되지 않는다면,
1. sidefooter 전역을 적용시키지 않을 것이라는 코드를 추가하거나
2. 가운데 중심 축소로 변경 필요




https://github.com/user-attachments/assets/aedc0528-8c46-45d3-94c7-2e875ba09d82


