### PR TITLE
[FEAT] 비밀번호 변경 이메일 전송 및 목업 데이터 비밀번호 변경 완료

### DIFF
--- a/server/login/login-test.json
+++ b/server/login/login-test.json
@@ -198,10 +198,10 @@
     {
       "id": "237a",
       "email": "rainyday1367@naver.com",
-      "password": "$2b$12$f90D7ZyB6TxDwOvT6jz/o.f.b9SXbRxAuSyOKTNq4/LX3ZUjp38t2",
+      "password": "$2b$10$HSejfAB3MKiC/Lzxk8vAPeROxMPyAXyhyEJ6TtTR8tO53moXgOcLS",
       "name": "뉴덩할",
       "nickname": "뉴뉴덩할",
-      "birthday": "2025-04-13T15:00:00.000Z",
+      "birthday": "2025-04-13",
       "image": null,
       "status": "is_active",
       "black_date": null,

--- a/src/pages/SignupPage.vue
+++ b/src/pages/SignupPage.vue
@@ -131,7 +131,7 @@ const handleSignup = async () => {
   const salt = bcrypt.genSaltSync(12); // 12단계 보안
   const hashedPassword = bcrypt.hashSync(password.value, salt); // 🔐 여기서 해싱
   // 목업 데이터 연결
-  const now = new Date().toISOString().replace("T", " ").substring(0, 19);
+  const birthday = new Date(birthday.value).toISOString().split("T")[0]; // "YYYY-MM-DD"만 추출
 
   try {
     const response = await fetch('http://localhost:3000/members', {
@@ -142,7 +142,7 @@ const handleSignup = async () => {
         password: hashedPassword, // 🔐 해시된 비밀번호
         name: name.value,
         nickname: nickname.value,
-        birthday: birth.value,
+        birthday: birthday,
         image: null,
         status: 'is_active',
         black_date: null,


### PR DESCRIPTION
## 🎯 작업 내용 (What I did)
> 이 PR에서 작업한 내용을 간략히 설명해주세요.
백엔드와의 서버 연동을 통해 이메일로 바뀐 비밀번호를 받고
그것을 목업 데이터에 수정시켜서 bcrypt 암호화를 통해 목업 데이터에 저장하는 것을 구현
회원 데이터에 생년 월일 형식 실제 DB와 맞지 않아 그 부분도 추가 수정하였습니다:))

## 📌 변경 사항 (Changes)
- [ ] 주요 기능 추가 / 변경
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 기타 (설명 필요)

## 📂 관련 이슈 (Issue)
- 관련된 이슈가 있다면 이곳에 연결하세요. (`#이슈번호`)
- #35 #43 

## ✅ 체크리스트 (Checklist)
- [ ] 코드에 오류가 없는지 확인하셨나요?
- [ ] 주요 변경 사항을 문서화하셨나요?
- [ ] 단위 테스트 또는 통합 테스트를 추가했나요? (해당하는 경우)
- [ ] 리뷰어가 확인해야 할 포인트가 있다면 적어주세요.

## 💡 추가 설명 (Additional Info)
> 리뷰어가 알면 좋은 추가적인 내용을 적어주세요. (예: 기술적 의사 결정, 고려사항 등)

https://github.com/user-attachments/assets/42014fb7-ebdb-4e09-895a-70b60a683cae


---
